### PR TITLE
add chainId param to payment request, add expectedNetwork param in ap…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -318,11 +318,14 @@ class App extends React.Component<any, any> {
     const { paymentRequest, paymentStatus } = this.state;
     if (paymentRequest && paymentStatus) {
       if (typeof window !== "undefined") {
-        const url = appendToQueryString(paymentRequest.callbackUrl, {
-          txhash: paymentStatus.result,
-          currency: paymentRequest.currency,
-        });
-        window.open(url);
+        // open callback if defined. decodeURIComponent returns string(undefiend).
+        if (paymentRequest.callbackUrl!=="undefined") {
+          const url = appendToQueryString(paymentRequest.callbackUrl, {
+            txhash: paymentStatus.result,
+            currency: paymentRequest.currency,
+          });        
+          window.open(url);
+        }
       } else {
         return this.displayErrorMessage("Window is undefined");
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { BigNumber, Contract, providers, utils } from "ethers";
 
 import Web3Modal from "web3modal";
-import {CHAIN_DATA_LIST} from "web3modal";
+import { CHAIN_DATA_LIST } from "web3modal";
 import WalletConnectProvider from "@walletconnect/web3-provider";
 import Fortmatic from "fortmatic";
 import Torus from "@toruslabs/torus-embed";
@@ -29,9 +29,9 @@ import {
   PAYMENT_FAILURE,
   PAYMENT_PENDING,
 } from "./constants/paymentStatus";
-import { SUPPORTED_ASSETS } from "./constants/supported";
+import { SUPPORTED_ASSETS, SUPPORTED_CHAINS } from "./constants/supported";
 import { ERC20 } from "./helpers/abi";
-import { getChain, getSupportedNetworkByAssetSymbol } from "./helpers/chains";
+import { getChain } from "./helpers/chains";
 
 const SLayout = styled.div`
   position: relative;
@@ -184,9 +184,13 @@ class App extends React.Component<any, any> {
               amount: queryParams.amount,
               to: queryParams.to,
               callbackUrl: decodeURIComponent(queryParams.callbackUrl) || "",
-              chainId: queryParams.chainId || 1,
+              chainId: parseInt(queryParams.chainId) || 1,
               data: queryParams.data || "",
             };
+            // check network support:
+            if (typeof SUPPORTED_CHAINS[result.chainId] === "undefined") {
+              throw new Error("The app can't handle this network currently...");
+            }
           } catch (error) {
             result = undefined;
             console.error(error);
@@ -238,19 +242,10 @@ class App extends React.Component<any, any> {
     }
   };
 
-  public getAsset = (assetSymbol: string, chainId?: number): IAssetData => {
+  public getAsset = (assetSymbol: string, chainId: number): IAssetData => {
     let result: IAssetData | undefined = undefined;
-    if (assetSymbol === "eth" && chainId !== 1) {
-      throw new Error(
-        "Please switch to Ethereum Mainnet and refresh this page"
-      );
-    }
-    if (assetSymbol === "xdai" && chainId !== 100) {
-      throw new Error("Please switch to xDAI and refresh this page");
-    }
-    if (chainId && SUPPORTED_ASSETS[chainId]) {
-      result =
-        SUPPORTED_ASSETS[chainId][assetSymbol.toLowerCase()] || undefined;
+    if (SUPPORTED_ASSETS[chainId]) {
+      result = SUPPORTED_ASSETS[chainId][assetSymbol.toLowerCase()] || undefined;
     }
     if (typeof result === "undefined") {
       throw new Error(`Asset request is not supported: ${assetSymbol}`);
@@ -259,7 +254,7 @@ class App extends React.Component<any, any> {
   };
 
   public requestTransaction = async () => {
-    const { provider, paymentRequest, chain } = this.state;
+    const { provider, paymentRequest } = this.state;
     if (paymentRequest) {
       const { amount, to, data, callbackUrl } = paymentRequest;
       const assetSymbol = paymentRequest.currency.toLowerCase();
@@ -270,7 +265,7 @@ class App extends React.Component<any, any> {
       }
       let asset: IAssetData;
       try {
-        asset = this.getAsset(assetSymbol, chain?.chainId);
+        asset = this.getAsset(assetSymbol, paymentRequest.chainId);
       } catch (e) {
         return this.displayErrorMessage(e.message);
       }
@@ -366,10 +361,7 @@ class App extends React.Component<any, any> {
     const { paymentRequest, paymentStatus } = this.state;
     if (paymentRequest && paymentStatus) {
       const txHash = paymentStatus.result;
-      const url =
-        paymentRequest.currency.toLowerCase() === "xdai"
-          ? `https://blockscout.com/poa/dai/tx/${txHash}`
-          : `https://etherscan.io/tx/${txHash}`;
+      const url = `${SUPPORTED_CHAINS[paymentRequest.chainId].blockExplorerUrl}/tx/${txHash}`;
       return (
         <SDisplayTxHash href={url} target="blank" rel="noreferrer noopener">
           {txHash}
@@ -417,7 +409,7 @@ class App extends React.Component<any, any> {
                 <SPaymentRequestDescription>
                   {`Paying `}
                   <span>{`${paymentRequest.amount} ${paymentRequest.currency}`}</span>
-                  {` to ${paymentRequest.to}`}
+                  {` to ${paymentRequest.to} on ${SUPPORTED_CHAINS[paymentRequest.chainId].name} network`}
                 </SPaymentRequestDescription>
                 {!paymentStatus ? (
                   <ConnectButton label="Pay" onClick={this.onConnect} />

--- a/src/constants/supported.ts
+++ b/src/constants/supported.ts
@@ -1,23 +1,39 @@
 import { IAssetData } from "../helpers/types";
 
 interface ISupportedChains {
-  [network: string]: {
+  [chainId: number]: {
     name: string;
     chainId: number;
     assets: string[];
+    blockExplorerUrl: string;
   };
 }
 
 export const SUPPORTED_CHAINS: ISupportedChains = {
-  mainnet: {
+  1: {
     name: "Ethereum",
     chainId: 1,
-    assets: ["eth", "sai", "dai"],
+    assets: ["eth", "dai"],
+    blockExplorerUrl: "https://etherscan.io",
   },
-  xdai: {
+  3: {
+    name: "Ethereum Ropsten Testnet",
+    chainId: 3,
+    assets: ["eth", "dai"],
+    blockExplorerUrl: "https://ropsten.etherscan.io",
+
+  },
+  4: {
+    name: "Ethereum Rinkeby Testnet",
+    chainId: 4,
+    assets: ["eth", "dai"],
+    blockExplorerUrl: "https://rinkeby.etherscan.io",
+  },
+  100: {
     name: "xDAI",
     chainId: 100,
     assets: ["xdai"],
+    blockExplorerUrl: "https://blockscout.com/poa/dai",
   },
 };
 
@@ -35,17 +51,39 @@ export const SUPPORTED_ASSETS: ISupportedAssets = {
       decimals: "18",
       contractAddress: "",
     },
-    sai: {
-      symbol: "SAI",
-      name: "SAI Stablecoin",
-      decimals: "18",
-      contractAddress: "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
-    },
     dai: {
       symbol: "DAI",
       name: "DAI Stablecoin",
       decimals: "18",
       contractAddress: "0x6b175474e89094c44da98b954eedeac495271d0f",
+    },
+  },
+  3: {
+    eth: {
+      symbol: "ETH",
+      name: "Ethereum",
+      decimals: "18",
+      contractAddress: "",
+    },
+    dai: {
+      symbol: "DAI",
+      name: "DAI Stablecoin",
+      decimals: "18",
+      contractAddress: "0xad6d458402f60fd3bd25163575031acdce07538d",
+    },
+  },
+  4: {
+    eth: {
+      symbol: "ETH",
+      name: "Ethereum",
+      decimals: "18",
+      contractAddress: "",
+    },
+    dai: {
+      symbol: "DAI",
+      name: "DAI Stablecoin",
+      decimals: "18",
+      contractAddress: "0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735",
     },
   },
   100: {

--- a/src/helpers/chains.ts
+++ b/src/helpers/chains.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 
 import { IChainData } from "./types";
-import { SUPPORTED_CHAINS } from "../constants/supported";
 
 const EIP155_API_URL = "https://chainid.network/chains.json";
 
@@ -27,14 +26,4 @@ export async function getChain(chainId: string) {
     default:
       throw new Error(`Chain namespace not supported for chainId: ${chainId}`);
   }
-}
-
-export function getSupportedNetworkByAssetSymbol(assetSymbol: string): string {
-  let match = Object.keys(SUPPORTED_CHAINS).find((key) =>
-    SUPPORTED_CHAINS[key].assets.includes(assetSymbol.toLowerCase())
-  );
-  if (typeof match === "undefined") {
-    throw new Error(`No supported chain found for currency: ${assetSymbol}`);
-  }
-  return match;
 }


### PR DESCRIPTION
* Added chainId parameter to the URL (handled by `paymentRequest`. This defaults to 1 if no chainId is specified.
* Add `expectedNetwork` parameter to tell Web3Modal which network to connect to. This enabled web3checkout to throw an error if not connected to the right network.

## Next Steps:
* refactor `getAsset()`, `renderTxHash()`

## Expected Breaking Change
* `xdai` will only work when the `chainId=100` is specified. This is okay because in the final state, I expect web3modal-checkout to stop using the hardcoded list of networks and be more flexible.


